### PR TITLE
Add initial infrastructure for P4Runtime mapping logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 p4src/build
-ptf/*.log
-ptf/*.pcap
+ptf/log
+.yapf

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style = google
+column_limit = 100
+split_before_named_assigns = false

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,11 @@ graph: p4src/bng.p4
 
 check:
 	@cd ptf && PTF_DOCKER_IMG=$(PTF_IMG) ./run_tests $(TEST)
+
+.yapf:
+	rm -rf ./yapf
+	git clone --depth 1 https://github.com/google/yapf.git .yapf
+	rm -rf .yapf/.git
+
+prettify: .yapf
+	PYTHONPATH=${curr_dir}/.yapf python .yapf/yapf -ir -e .yapf/ ptf/mapr

--- a/ptf/lib/start_bmv2.sh
+++ b/ptf/lib/start_bmv2.sh
@@ -3,6 +3,7 @@
 set -xe
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+LOGDIR=${DIR}/../log
 
 CPU_PORT=255
 GRPC_PORT=28000
@@ -44,17 +45,14 @@ for idx in 0 1 2 3 4 5 6 7; do
     fi
 done
 
-rm -f p4rt_write.log
-rm -f stratum_bmv2.log
-
 # shellcheck disable=SC2086
 stratum_bmv2 \
     --external_stratum_urls=0.0.0.0:${GRPC_PORT} \
     --persistent_config_dir=/tmp \
     --forwarding_pipeline_configs_file=/dev/null \
     --chassis_config_file="${DIR}"/chassis_config.pb.txt \
-    --write_req_log_file=p4rt_write.log \
+    --write_req_log_file=${LOGDIR}/stratum_p4rt_write.log \
     --initial_pipeline=/root/dummy.json \
     --bmv2_log_level=trace \
-    --cpu_port 255 \
-    > stratum_bmv2.log 2>&1
+    --cpu_port=${CPU_PORT} \
+    > ${LOGDIR}/stratum_bmv2.log 2>&1

--- a/ptf/lib/start_mapr.sh
+++ b/ptf/lib/start_mapr.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+MAPR_PY=$(readlink -f "${DIR}"/../mapr/mapr.py)
+MAPR_LOG=$(readlink -f "${DIR}"/../log/mapr.log)
+
+python -u "${MAPR_PY}" --server-port 28001 --target-addr localhost:28000 > "${MAPR_LOG}" 2>&1

--- a/ptf/mapr/mapr.py
+++ b/ptf/mapr/mapr.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python2
+
+# Copyright 2020-present Open Networking Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import time
+import traceback
+from functools import wraps
+
+import grpc
+from concurrent import futures
+from google.protobuf import text_format
+from p4.v1 import p4runtime_pb2_grpc
+
+DEFAULT_TIMEOUT = 10
+
+
+def explained_msg(msg):
+    """
+    Returns a string explaining the given Protobuf message.
+    """
+    name = msg.__class__.__name__
+    oneline = text_format.MessageToString(msg, as_one_line=True)
+    if len(oneline) > 255:
+        oneline = oneline[0:255] + '... TRUNCATED!'
+    return "%s { %s }" % (name, oneline)
+
+
+def explained_error(grpc_error):
+    """
+    Returns a string explaining the given gRPC error.
+    """
+    assert isinstance(grpc_error, grpc.RpcError)
+    return "%s: %s" % (grpc_error.code(), grpc_error.details())
+
+
+def logged_msg_iterator(iterator, fmt):
+    """
+    Returns an iterator that logs all messages in the given one using the given format.
+    """
+    for msg in iterator:
+        print(fmt % explained_msg(msg))
+        yield msg
+
+
+def logged_unary(f):
+    """
+    Servicer method annotation logs request and response for unary RPCs.
+    """
+
+    @wraps(f)
+    def handle(*args, **kwargs):
+        assert isinstance(args[0], RelayP4RuntimeServicer)
+        request = args[1]
+        print(">> %s" % explained_msg(request))
+        response = f(*args, **kwargs)
+        print("<< %s " % explained_msg(response))
+        return response
+
+    return handle
+
+
+def logged_server_stream(f):
+    """
+    Servicer method annotation logs request and responses for server stream RPCs.
+    """
+
+    @wraps(f)
+    def handle(*args, **kwargs):
+        assert isinstance(args[0], RelayP4RuntimeServicer)
+        request = args[1]
+        print(">> %s" % explained_msg(request))
+        response = f(*args, **kwargs)
+        return logged_msg_iterator(response, "<< %s ")
+
+    return handle
+
+
+def logged_bidi_stream(f):
+    """
+    Servicer method annotation logs requests and responses for bidirectional stream RPCs.
+    """
+
+    @wraps(f)
+    def handle(*args, **kwargs):
+        assert isinstance(args[0], RelayP4RuntimeServicer)
+        # Replace request iterator in args with a logged one
+        new_args = list(args)
+        new_args[1] = logged_msg_iterator(args[1], '<< %s')
+        # Return logged response iterator
+        return logged_msg_iterator(f(*new_args, **kwargs), '>> %s')
+
+    return handle
+
+
+def relay_rpc_errors(f):
+    """
+    Servicer method annotation relays gRPC errors from the target.
+    """
+
+    @wraps(f)
+    def handle(*args, **kwargs):
+        assert isinstance(args[0], RelayP4RuntimeServicer)
+        assert isinstance(args[2], grpc.ServicerContext)
+        context = args[2]
+        try:
+            return f(*args, **kwargs)
+        except grpc.RpcError as e:
+            print("<< %s" % explained_error(e))
+            context.set_code(e.code())
+            context.set_details(e.details())
+        except Exception as ex:
+            traceback.print_exc()
+            context.set_code(grpc.StatusCode.UNKNOWN)
+            context.set_details("Mapper error: %s" % ex.message)
+
+    return handle
+
+
+class RelayP4RuntimeServicer(p4runtime_pb2_grpc.P4RuntimeServicer):
+    """
+    Implementation of a P4Runtime servicer that relays all calls to a given target.
+    """
+
+    def __init__(self, channel):
+        self.stub = p4runtime_pb2_grpc.P4RuntimeStub(channel)
+
+    @relay_rpc_errors
+    @logged_unary
+    def Write(self, request, context):
+        return self.stub.Write(request, timeout=DEFAULT_TIMEOUT)
+
+    @relay_rpc_errors
+    @logged_server_stream
+    def Read(self, request, context):
+        return self.stub.Read(request, timeout=DEFAULT_TIMEOUT)
+
+    @relay_rpc_errors
+    @logged_unary
+    def SetForwardingPipelineConfig(self, request, context):
+        return self.stub.SetForwardingPipelineConfig(request, timeout=DEFAULT_TIMEOUT)
+
+    @relay_rpc_errors
+    @logged_unary
+    def GetForwardingPipelineConfig(self, request, context):
+        return self.stub.GetForwardingPipelineConfig(request, timeout=DEFAULT_TIMEOUT)
+
+    @relay_rpc_errors
+    @logged_bidi_stream
+    def StreamChannel(self, request_iterator, context):
+        return self.stub.StreamChannel(request_iterator)
+
+
+def mapr_start(target_addr, server_port):
+    """
+    Starts the mapr server.
+    """
+    # create a gRPC server
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=5))
+    channel = grpc.insecure_channel(target_addr)
+    p4runtime_pb2_grpc.add_P4RuntimeServicer_to_server(RelayP4RuntimeServicer(channel), server)
+
+    # listen on port 50051
+    print('Starting mapr server. Listening on port %d...' % server_port)
+    server.add_insecure_port('[::]:%d' % server_port)
+    server.start()
+    return server
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="P4Runtime mapper")
+    parser.add_argument(
+        '--server-port',
+        help='Port where the mapr server will listen for P4Runtime RPCs',
+        type=int,
+        default='28001',
+    )
+    parser.add_argument(
+        '--target-addr',
+        help='Address of the target P4Runtime server',
+        type=str,
+        default='localhost:28000',
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    server = mapr_start(args.target_addr, args.server_port)
+    # since server.start() will not block,
+    # a sleep-loop is added to keep alive
+    try:
+        while True:
+            time.sleep(86400)
+    except KeyboardInterrupt:
+        server.stop(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/ptf/mapr/test.py
+++ b/ptf/mapr/test.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python2
+
+# Copyright 2020-present Open Networking Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from functools import wraps
+
+import grpc
+from concurrent import futures
+from p4.v1 import p4runtime_pb2_grpc
+from p4.v1.p4runtime_pb2 import WriteRequest, StreamMessageRequest, WriteResponse, ReadResponse, \
+    SetForwardingPipelineConfigResponse, GetForwardingPipelineConfigResponse, StreamMessageResponse, \
+    SetForwardingPipelineConfigRequest, GetForwardingPipelineConfigRequest, ReadRequest
+
+from mapr import mapr_start
+
+
+def fail_on_grpc_error(f):
+    """
+    Function annotation that fails a test in case of a gRPC runtime error
+    """
+
+    @wraps(f)
+    def handle(*args, **kwargs):
+        test = args[0]
+        assert isinstance(test, unittest.TestCase)
+        try:
+            return f(*args, **kwargs)
+        except grpc.RpcError as e:
+            test.fail("gRPC Error: %s %s" % (e.code(), e.details()))
+
+    return handle
+
+
+class MockP4RuntimeServicer(p4runtime_pb2_grpc.P4RuntimeServicer):
+    """
+    Mock target P4Runtime servicer
+    """
+
+    def Write(self, request, context):
+        return WriteResponse()
+
+    def Read(self, request, context):
+        for i in range(3):
+            yield ReadResponse()
+
+    def SetForwardingPipelineConfig(self, request, context):
+        return SetForwardingPipelineConfigResponse()
+
+    def GetForwardingPipelineConfig(self, request, context):
+        return GetForwardingPipelineConfigResponse()
+
+    def StreamChannel(self, request_iterator, context):
+        for i in range(3):
+            yield StreamMessageResponse()
+
+
+class MaprTest(unittest.TestCase):
+    """
+    Base class for all mapr test cases
+    """
+    mapr = None
+    stub = None
+    mock_server = None
+
+    def setUp(self):
+        mapr_port = 280001
+        target_port = 28000
+        # stub -> 28001 (mapr) -> 28000 (mock_server)
+        self.mock_server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+        p4runtime_pb2_grpc.add_P4RuntimeServicer_to_server(
+            MockP4RuntimeServicer(),
+            self.mock_server,
+        )
+        print('Starting P4RT mock server. Listening on port %d...' % target_port)
+        self.mock_server.add_insecure_port('[::]:%d' % target_port)
+        self.mock_server.start()
+
+        self.mapr = mapr_start(target_addr="localhost:%d" % target_port, server_port=mapr_port)
+        self.stub = p4runtime_pb2_grpc.P4RuntimeStub(
+            grpc.insecure_channel("localhost:%d" % mapr_port))
+
+    def tearDown(self):
+        if self.mapr:
+            self.mapr.stop(0)
+        if self.mock_server:
+            self.mock_server.stop(0)
+
+
+class WriteTest(MaprTest):
+
+    @fail_on_grpc_error
+    def test(self):
+        req = WriteRequest()
+        response = self.stub.Write(req)
+        self.assertIsInstance(response, WriteResponse)
+
+
+class ReadTest(MaprTest):
+
+    @fail_on_grpc_error
+    def test(self):
+        req = ReadRequest()
+        for response in self.stub.Read(req):
+            self.assertIsInstance(response, ReadResponse)
+
+
+class SetForwardingPipelineConfigTest(MaprTest):
+
+    @fail_on_grpc_error
+    def test(self):
+        req = SetForwardingPipelineConfigRequest()
+        response = self.stub.SetForwardingPipelineConfig(req)
+        self.assertIsInstance(response, SetForwardingPipelineConfigResponse)
+
+
+class GetForwardingPipelineConfigTest(MaprTest):
+
+    @fail_on_grpc_error
+    def test(self):
+        req = GetForwardingPipelineConfigRequest()
+        response = self.stub.GetForwardingPipelineConfig(req)
+        self.assertIsInstance(response, GetForwardingPipelineConfigResponse)
+
+
+class StreamChannelTest(MaprTest):
+
+    @fail_on_grpc_error
+    def test(self):
+
+        def req_iterator():
+            for i in range(3):
+                yield StreamMessageRequest()
+
+        for res in self.stub.StreamChannel(req_iterator()):
+            self.assertIsInstance(res, StreamMessageResponse)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ptf/run_tests
+++ b/ptf/run_tests
@@ -13,7 +13,10 @@ function stop() {
         echo "Stopping container ${runName}..."
         docker stop -t0 "${runName}" > /dev/null
 }
-trap stop INT
+trap stop EXIT
+
+rm -rf log
+mkdir log
 
 echo "*** Starting stratum_bmv2 in Docker (${runName})..."
 docker run --name "${runName}" -d --privileged --rm \
@@ -22,18 +25,20 @@ docker run --name "${runName}" -d --privileged --rm \
     "${PTF_DOCKER_IMG}" \
     ./lib/start_bmv2.sh > /dev/null
 
-sleep 2
+sleep 1
 
-set +e
+printf "*** Starting mapr...\n"
+docker exec -d "${runName}" ./lib/start_mapr.sh
+
+sleep 1
 
 printf "*** Starting tests...\n"
-docker exec "${runName}" ./lib/runner.py \
+docker exec "${runName}" python -u ./lib/runner.py \
     --bmv2-json /p4c-out/bmv2.json \
     --p4info /p4c-out/p4info.bin \
-    --grpc-addr localhost:28000 \
+    --grpc-addr localhost:28001 \
     --device-id 1 \
     --ptf-dir ./tests \
     --cpu-port 255 \
+    --log-file ./log/ptf.log \
     --port-map /ptf/lib/port_map.json "${@}"
-
-stop


### PR DESCRIPTION
This PR adds "mapr", a Python-based P4Runtime server that relays RPCs to
a second P4Runtime server (target). The current implementation doesn't
modify RPC's requests, but it will in future.

To verify that it works properly, mapr is executed as part of the PTF
tests (make check), thus relaying P4Runtime write requests to
stratum_bmv2. All relayed requests and responses are logged in
ptf/log/mapr.log.