### PR TITLE
Assume CONTINUE_ON_ERROR atomicity for WriteRequest

### DIFF
--- a/mapr/fabric/fabric.go
+++ b/mapr/fabric/fabric.go
@@ -57,6 +57,6 @@ func (p fabricChangeProcessor) HandleMyStationEntry(e *translate.MyStationEntry,
 
 func (p fabricChangeProcessor) HandleAttachmentEntry(a *translate.AttachmentEntry, ok bool) ([]*v1.Update, error) {
 	log.Tracef("AttachmentEntry={ %s }, complete=%v", a, ok)
-	log.Warnf("fabricChangeProcessor.HandleMyStationEntry(): not implemented")
+	log.Warnf("fabricChangeProcessor.HandleAttachmentEntry(): not implemented")
 	return nil, nil
 }

--- a/mapr/translate/dummy.go
+++ b/mapr/translate/dummy.go
@@ -13,6 +13,6 @@ func NewDummyTranslator() Translator {
 }
 
 // Returns the same input request.
-func (d dummy) Translate(request *p4v1.WriteRequest) (*p4v1.WriteRequest, error) {
-	return request, nil
+func (d dummy) Translate(u *p4v1.Update) ([]*p4v1.Update, error) {
+	return []*p4v1.Update{u}, nil
 }

--- a/mapr/translate/p4rt_store_test.go
+++ b/mapr/translate/p4rt_store_test.go
@@ -12,17 +12,12 @@ var mockUpdateInsertTableEntry1 = p4v1.Update{
 	Entity: &p4v1.Entity{Entity: &p4v1.Entity_TableEntry{TableEntry: &mockTableEntry1}},
 }
 
-var mockUpdateInsertTableEntry2 = p4v1.Update{
-	Type:   p4v1.Update_INSERT,
-	Entity: &p4v1.Entity{Entity: &p4v1.Entity_TableEntry{TableEntry: &mockTableEntry2}},
-}
-
 func Test_store_Update(t *testing.T) {
 	type fields struct {
 		tableEntries map[string]*p4v1.TableEntry
 	}
 	type args struct {
-		req    *p4v1.WriteRequest
+		update *p4v1.Update
 		dryRun bool
 	}
 	tests := []struct {
@@ -35,28 +30,10 @@ func Test_store_Update(t *testing.T) {
 			name:   "insert 1 table entry",
 			fields: fields{emptyTableEntries},
 			args: args{
-				req: &p4v1.WriteRequest{
-					Updates: []*p4v1.Update{
-						&mockUpdateInsertTableEntry1,
-					},
-				},
+				update: &mockUpdateInsertTableEntry1,
 				dryRun: false,
 			},
 			wantTableEntryCount: 1,
-		},
-		{
-			name:   "insert 2 table entries",
-			fields: fields{emptyTableEntries},
-			args: args{
-				req: &p4v1.WriteRequest{
-					Updates: []*p4v1.Update{
-						&mockUpdateInsertTableEntry1,
-						&mockUpdateInsertTableEntry2,
-					},
-				},
-				dryRun: false,
-			},
-			wantTableEntryCount: 2,
 		},
 	}
 	for _, tt := range tests {
@@ -64,7 +41,7 @@ func Test_store_Update(t *testing.T) {
 			s := &p4RtStore{
 				tableEntries: tt.fields.tableEntries,
 			}
-			s.Update(tt.args.req, tt.args.dryRun)
+			s.Update(tt.args.update, tt.args.dryRun)
 			if gotTableEntryCount := s.TableEntryCount(); gotTableEntryCount != tt.wantTableEntryCount {
 				t.Errorf("TableEntryCount() = %v, want %v", gotTableEntryCount, tt.wantTableEntryCount)
 			}

--- a/ptf/lib/base_test.py
+++ b/ptf/lib/base_test.py
@@ -228,11 +228,13 @@ class P4RuntimeErrorIterator:
                 error.ParseFromString(meta[1])
                 break
         if error is None:
-            raise P4RuntimeErrorFormatException("No binary details field")
+            raise grpc_error
+            # raise P4RuntimeErrorFormatException("No binary details field")
 
         if len(error.details) == 0:
-            raise P4RuntimeErrorFormatException(
-                "Binary details field has empty Any details repeated field")
+            raise grpc_error
+            # raise P4RuntimeErrorFormatException(
+            #     "Binary details field has empty Any details repeated field")
         self.errors = error.details
         self.idx = 0
 


### PR DESCRIPTION
That allows us to simplify the translator and store implementation, by evaluating logical updates one-by-one, rather than in batches. As a consequence, given a logical WriteRequest with N updates, the new implementation might generate up to N physical WriteRequests for the target. That's bad for performance, but for now it makes it easier to reason about the translation logic and the stores.

Also, add support for storing action profile groups and members.